### PR TITLE
Add Pythonium to Python tooling / 2021-11-01-python-cribsheet.markdown

### DIFF
--- a/_posts/2021-11-01-python-cribsheet.markdown
+++ b/_posts/2021-11-01-python-cribsheet.markdown
@@ -26,6 +26,7 @@ See also: my [reference python repo](https://github.com/anniecherk/python-repo-t
 - [pyenv](https://github.com/pyenv/pyenv): manages switches between different versions of the python interpretter
 - [tox](https://tox.wiki/en/latest/index.html): test code against different python versions
 - [pythex](https://pythex.org/): online regex sandbox
+- [pythonium](https://pythonium.net/): online formatter, code checker and visual regex sandbox
 
 # Python libraries:
 - [argparse](https://docs.python.org/3/library/argparse.html): for building CLI tools which take arguments


### PR DESCRIPTION
Hello, I added Pythonium (my website), which provides formatter, code checker and a visual regex tester for Python, to "Python tooling" / 2021-11-01-python-cribsheet.markdown